### PR TITLE
[Hgi] Add HgiGLWrapper to expose HgiGL to Swift

### DIFF
--- a/SwiftUsd.docc/AboutThisRepo/ChangeLog.md
+++ b/SwiftUsd.docc/AboutThisRepo/ChangeLog.md
@@ -11,6 +11,10 @@ Changes to SwiftUsd
     ```
 }
 
+### TBD
+Released TBD, based on OpenUSD TBD
+- Add `Overlay.HgiGLWrapper`, exposing HgiGL alongside HgiMetal in the Swift bindings
+
 ### 7.0.1
 Released 2026-06-04, based on OpenUSD v26.05
 - Enable compatibility with Swift main-snapshot-2026-05-27

--- a/SwiftUsd.docc/WrappedSymbolDocumentation/WrappedTypes.md
+++ b/SwiftUsd.docc/WrappedSymbolDocumentation/WrappedTypes.md
@@ -26,6 +26,7 @@ Access these types by prefixing their name with `Overlay`
 - ``OpenUSD/Overlay/UsdPrimTypeInfoWrapper``
 - ``OpenUSD/Overlay/HioImageWrapper``
 - ``OpenUSD/Overlay/HgiWrapper``
+- ``OpenUSD/Overlay/HgiGLWrapper``
 - ``OpenUSD/Overlay/HgiMetalWrapper``
 - ``OpenUSD/Overlay/UsdImagingGLEngineWrapper``
 - ``OpenUSD/Overlay/UsdAppUtilsFrameRecorderWrapper``

--- a/source/Wrappers/HgiGLWrapper.cpp
+++ b/source/Wrappers/HgiGLWrapper.cpp
@@ -1,0 +1,64 @@
+//===----------------------------------------------------------------------===//
+// This source file is part of github.com/apple/SwiftUsd
+//
+// Copyright © 2025 Apple Inc. and the SwiftUsd project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//===----------------------------------------------------------------------===//
+
+#include "swiftUsd/defines.h"
+#if SwiftUsd_PXR_ENABLE_IMAGING_SUPPORT
+
+#include "swiftUsd/Wrappers/HgiGLWrapper.h"
+
+Overlay::HgiGLWrapper::HgiGLWrapper() :
+    Overlay::HgiWrapper(std::make_shared<pxr::HgiGL>())
+{}
+
+pxr::HgiGLDevice* Overlay::HgiGLWrapper::GetPrimaryDevice() const {
+    return get()->GetPrimaryDevice();
+}
+
+pxr::HgiGLContextArenaHandle Overlay::HgiGLWrapper::CreateContextArena() {
+    return get()->CreateContextArena();
+}
+
+void Overlay::HgiGLWrapper::DestroyContextArena(pxr::HgiGLContextArenaHandle*_Nonnull arenaHandle) {
+    get()->DestroyContextArena(arenaHandle);
+}
+
+void Overlay::HgiGLWrapper::SetContextArena(const pxr::HgiGLContextArenaHandle& arenaHandle) {
+    get()->SetContextArena(arenaHandle);
+}
+
+// MARK: SwiftUsd implementation access
+
+Overlay::HgiGLWrapper::HgiGLWrapper(std::shared_ptr<pxr::HgiGL> _ptr) : Overlay::HgiWrapper(_ptr) {}
+
+Overlay::HgiGLWrapper::HgiGLWrapper(Overlay::HgiWrapper hgi) : Overlay::HgiWrapper(hgi) {
+    if (!dynamic_cast<const pxr::HgiGL*>(_ptr.get())) {
+        _ptr = nullptr;
+    }
+}
+
+pxr::HgiGL* Overlay::HgiGLWrapper::get() const {
+    return std::static_pointer_cast<pxr::HgiGL>(_ptr).get();
+}
+
+std::shared_ptr<pxr::HgiGL> Overlay::HgiGLWrapper::get_shared() const {
+    return std::static_pointer_cast<pxr::HgiGL>(_ptr);
+}
+
+#endif // #if SwiftUsd_PXR_ENABLE_IMAGING_SUPPORT

--- a/source/Wrappers/HgiGLWrapper.h
+++ b/source/Wrappers/HgiGLWrapper.h
@@ -1,0 +1,91 @@
+//===----------------------------------------------------------------------===//
+// This source file is part of github.com/apple/SwiftUsd
+//
+// Copyright © 2025 Apple Inc. and the SwiftUsd project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//===----------------------------------------------------------------------===//
+
+// Original documentation for pxr::HgiGL from
+// https://github.com/PixarAnimationStudios/OpenUSD/blob/v26.05/pxr/imaging/hgiGL/hgi.h
+
+#ifndef SWIFTUSD_WRAPPERS_HGIGLWRAPPER_H
+#define SWIFTUSD_WRAPPERS_HGIGLWRAPPER_H
+
+#include "swiftUsd/defines.h"
+#if SwiftUsd_PXR_ENABLE_IMAGING_SUPPORT
+
+#include <stdio.h>
+#include <memory>
+#include "pxr/imaging/hgi/hgi.h"
+#include "pxr/imaging/hio/image.h"
+#include "pxr/imaging/hgiGL/hgi.h"
+#include "pxr/usdImaging/usdImagingGL/engine.h"
+#include "swiftUsd/Wrappers/HgiWrapper.h"
+
+namespace Overlay {
+    /// \class HgiGL
+    ///
+    /// OpenGL implementation of the Hydra Graphics Interface.
+    ///
+    /// \section GL Context Management
+    /// HgiGL expects any GL context(s) to be externally managed.
+    /// When HgiGL is constructed and during any of its resource create / destroy
+    /// calls and during command recording operations, it expects that an OpenGL
+    /// context is valid and current.
+    ///
+    class HgiGLWrapper final: public Overlay::HgiWrapper {
+    public:
+        // HgiGL interface, omitting inherited methods
+
+        //
+        // HgiGL specific
+        //
+
+        HgiGLWrapper();
+
+        /// Returns the opengl device.
+        pxr::HgiGLDevice*_Nullable GetPrimaryDevice() const;
+
+        /// Creates and return a context arena object handle.
+        pxr::HgiGLContextArenaHandle CreateContextArena();
+
+        /// Destroy a context arena.
+        /// Note: The context arena must be unset (by calling SetContextArena with
+        ///       an empty handle) prior to destruction.
+        void DestroyContextArena(pxr::HgiGLContextArenaHandle*_Nonnull arenaHandle);
+
+        /// Set the context arena to manage container resources (currently limited to
+        /// framebuffer objects) for graphics commands submitted subsequently.
+        void SetContextArena(const pxr::HgiGLContextArenaHandle& arenaHandle);
+
+        /// SwiftUsd wrapping constructor
+        HgiGLWrapper(std::shared_ptr<pxr::HgiGL> _ptr);
+
+        /// SwiftUsd static downcasting constructor. Check `operator bool()` to determine
+        /// if the downcast succeeded.
+        HgiGLWrapper(Overlay::HgiWrapper hgi);
+
+        /// Returns the underlying HgiGL wrapped by this instance
+        pxr::HgiGL*_Nullable get() const;
+
+        /// Returns the underlying HgiGL wrapped by this instance
+        std::shared_ptr<pxr::HgiGL> get_shared() const;
+    };
+}
+
+#endif // #if SwiftUsd_PXR_ENABLE_IMAGING_SUPPORT
+
+#endif /* SWIFTUSD_WRAPPERS_HGIGLWRAPPER_H */

--- a/source/swiftUsd.h
+++ b/source/swiftUsd.h
@@ -43,6 +43,7 @@
 #include "swiftUsd/CxxOnly/Deprecated.h"
 
 #include "swiftUsd/Wrappers/ArResolverWrapper.h"
+#include "swiftUsd/Wrappers/HgiGLWrapper.h"
 #include "swiftUsd/Wrappers/HgiMetalWrapper.h"
 #include "swiftUsd/Wrappers/HgiWrapper.h"
 #include "swiftUsd/Wrappers/HioImageWrapper.h"
@@ -67,6 +68,7 @@
 #includeforswiftdocc "swiftUsd/TfNotice/SwiftKey.h"
 
 #includeforswiftdocc "swiftUsd/Wrappers/ArResolverWrapper.h"
+#includeforswiftdocc "swiftUsd/Wrappers/HgiGLWrapper.h"
 #includeforswiftdocc "swiftUsd/Wrappers/HgiMetalWrapper.h"
 #includeforswiftdocc "swiftUsd/Wrappers/HgiWrapper.h"
 #includeforswiftdocc "swiftUsd/Wrappers/HioImageWrapper.h"


### PR DESCRIPTION
### Description
This PR introduces `HgiGLWrapper` to expose the underlying OpenUSD `HgiGL` type to Swift. 

Previously, users building cross-platform Hydra implementations had to rely on fragile compile-time guards to check for its presence. Exposing this type to Swift eliminates that friction.

### Related Issues / PRs
* **Resolves:** #28
* **Depends on Test PR:** https://github.com/apple/SwiftUsd-Tests/pull/12

### Checklist
- [x] Followed the contribution guidelines in `CONTRIBUTING.md`
- [x] Omitted local generation artifacts (`Package.swift` / `swift-package`) from the commit
- [x] Added corresponding verification tests in the test suite