### PR TITLE
[VtArray] Add zero-copy `withUnsafeBufferPointer` and single-copy buffer init

### DIFF
--- a/SwiftUsd.docc/AboutThisRepo/ChangeLog.md
+++ b/SwiftUsd.docc/AboutThisRepo/ChangeLog.md
@@ -16,6 +16,7 @@ Released TBD, based on OpenUSD TBD
 - Add `Overlay.HgiGLWrapper`, exposing HgiGL alongside HgiMetal in the Swift bindings
 - Add `Overlay.ExecUsdSystem`, exposing ExecUsdSystem in the Swift bindings
 - Add `Overlay.ArAssetWrapper`, `Overlay.ArWritableAssetWrapper`
+- Add zero-copy `VtArray` reads via `withUnsafeBufferPointer(_:)` and single-copy construction from an `UnsafeBufferPointer`
 
 ### 7.0.1
 Released 2026-06-04, based on OpenUSD v26.05

--- a/source/SwiftOverlay/VtArray.h
+++ b/source/SwiftOverlay/VtArray.h
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+// This source file is part of github.com/apple/SwiftUsd
+//
+// Copyright © 2025 Apple Inc. and the SwiftUsd project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFTUSD_SWIFTOVERLAY_VTARRAY_H
+#define SWIFTUSD_SWIFTOVERLAY_VTARRAY_H
+
+#include <type_traits>
+#include "pxr/base/vt/array.h"
+
+namespace __Overlay {
+    // expose `assign` in a way Swift will import. VtArray uses copy-on-write
+    // storage, so this constructs the array with a single copy of the source
+    // range, rather than the element-by-element push_back the Collection
+    // initializer falls back to.
+    template <typename VtArray, typename Element>
+    inline void VtArray_assign(VtArray& array, const Element* first, const Element* last) {
+        static_assert(std::is_same_v<VtArray, pxr::VtArray<Element>>);
+        array.assign(first, last);
+    }
+}
+
+#endif // SWIFTUSD_SWIFTOVERLAY_VTARRAY_H

--- a/source/SwiftOverlay/VtArrayProtocol.swift
+++ b/source/SwiftOverlay/VtArrayProtocol.swift
@@ -106,11 +106,20 @@ extension __Overlay {
         associatedtype ElementType
         func __beginUnsafe() -> UnsafePointer<ElementType>?
         func __endUnsafe() -> UnsafePointer<ElementType>?
+
+        func __cdataUnsafe() -> UnsafePointer<ElementType>?
+        func size() -> Int
+
+        mutating func __assign(_ p: UnsafeBufferPointer<ElementType>)
     }
 }
 extension __Overlay.VtArray_Sequence where Element == Self.ElementType {
     public func makeIterator() -> __Overlay.VtArray_Sequence_Iterator<Self> {
         .init(begin: __beginUnsafe(), end: __endUnsafe(), s: self)
+    }
+
+    public borrowing func withUnsafeBufferPointer<T, E>(_ code: (UnsafeBufferPointer<ElementType>) throws(E) -> T) throws(E) -> T {
+        try code(UnsafeBufferPointer(start: __cdataUnsafe(), count: size()))
     }
 }
 
@@ -132,63 +141,250 @@ extension __Overlay {
     }
 }
 
-extension pxr.VtBoolArray: __Overlay.VtArrayProtocol {}
-extension pxr.VtDoubleArray: __Overlay.VtArrayProtocol {}
-extension pxr.VtFloatArray: __Overlay.VtArrayProtocol {}
-extension pxr.VtHalfArray: __Overlay.VtArrayProtocol {}
+extension __Overlay.VtArrayProtocol {
+    public init(_ buffer: UnsafeBufferPointer<ElementType>) {
+        self.init()
+        self.__assign(buffer)
+    }
+}
 
-extension pxr.VtCharArray: __Overlay.VtArrayProtocol {}
-extension pxr.VtUCharArray: __Overlay.VtArrayProtocol {}
-extension pxr.VtShortArray: __Overlay.VtArrayProtocol {}
-extension pxr.VtUShortArray: __Overlay.VtArrayProtocol {}
-extension pxr.VtIntArray: __Overlay.VtArrayProtocol {}
-extension pxr.VtUIntArray: __Overlay.VtArrayProtocol {}
-extension pxr.VtInt64Array: __Overlay.VtArrayProtocol {}
-extension pxr.VtUInt64Array: __Overlay.VtArrayProtocol {}
+extension pxr.VtBoolArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
+extension pxr.VtDoubleArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
+extension pxr.VtFloatArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
+extension pxr.VtHalfArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
 
-extension pxr.VtVec4iArray: __Overlay.VtArrayProtocol {}
-extension pxr.VtVec3iArray: __Overlay.VtArrayProtocol {}
-extension pxr.VtVec2iArray: __Overlay.VtArrayProtocol {}
+extension pxr.VtCharArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
+extension pxr.VtUCharArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
+extension pxr.VtShortArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
+extension pxr.VtUShortArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
+extension pxr.VtIntArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
+extension pxr.VtUIntArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
+extension pxr.VtInt64Array: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
+extension pxr.VtUInt64Array: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
 
-extension pxr.VtVec4hArray: __Overlay.VtArrayProtocol {}
-extension pxr.VtVec3hArray: __Overlay.VtArrayProtocol {}
-extension pxr.VtVec2hArray: __Overlay.VtArrayProtocol {}
+extension pxr.VtVec4iArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
+extension pxr.VtVec3iArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
+extension pxr.VtVec2iArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
 
-extension pxr.VtVec4fArray: __Overlay.VtArrayProtocol {}
-extension pxr.VtVec3fArray: __Overlay.VtArrayProtocol {}
-extension pxr.VtVec2fArray: __Overlay.VtArrayProtocol {}
+extension pxr.VtVec4hArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
+extension pxr.VtVec3hArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
+extension pxr.VtVec2hArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
 
-extension pxr.VtVec4dArray: __Overlay.VtArrayProtocol {}
-extension pxr.VtVec3dArray: __Overlay.VtArrayProtocol {}
-extension pxr.VtVec2dArray: __Overlay.VtArrayProtocol {}
+extension pxr.VtVec4fArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
+extension pxr.VtVec3fArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
+extension pxr.VtVec2fArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
 
-extension pxr.VtMatrix4fArray: __Overlay.VtArrayProtocol {}
-extension pxr.VtMatrix3fArray: __Overlay.VtArrayProtocol {}
-extension pxr.VtMatrix2fArray: __Overlay.VtArrayProtocol {}
+extension pxr.VtVec4dArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
+extension pxr.VtVec3dArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
+extension pxr.VtVec2dArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
 
-extension pxr.VtMatrix4dArray: __Overlay.VtArrayProtocol {}
-extension pxr.VtMatrix3dArray: __Overlay.VtArrayProtocol {}
-extension pxr.VtMatrix2dArray: __Overlay.VtArrayProtocol {}
+extension pxr.VtMatrix4fArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
+extension pxr.VtMatrix3fArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
+extension pxr.VtMatrix2fArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
 
-extension pxr.VtRange3fArray: __Overlay.VtArrayProtocol {}
-extension pxr.VtRange3dArray: __Overlay.VtArrayProtocol {}
-extension pxr.VtRange2fArray: __Overlay.VtArrayProtocol {}
-extension pxr.VtRange2dArray: __Overlay.VtArrayProtocol {}
-extension pxr.VtRange1fArray: __Overlay.VtArrayProtocol {}
-extension pxr.VtRange1dArray: __Overlay.VtArrayProtocol {}
+extension pxr.VtMatrix4dArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
+extension pxr.VtMatrix3dArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
+extension pxr.VtMatrix2dArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
 
-extension pxr.VtIntervalArray: __Overlay.VtArrayProtocol {}
-extension pxr.VtRect2iArray: __Overlay.VtArrayProtocol {}
+extension pxr.VtRange3fArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
+extension pxr.VtRange3dArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
+extension pxr.VtRange2fArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
+extension pxr.VtRange2dArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
+extension pxr.VtRange1fArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
+extension pxr.VtRange1dArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
+
+extension pxr.VtIntervalArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
+extension pxr.VtRect2iArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
 
 // VtStringArray gains Codable conformance in Codable.swift,
 // but it can't satisfy the requirements that ElementType is Codable
 // because std.string isn't Codable
-extension pxr.VtStringArray: __Overlay.VtArray_WithoutCodableProtocol {}
-extension pxr.VtTokenArray: __Overlay.VtArrayProtocol {}
+extension pxr.VtStringArray: __Overlay.VtArray_WithoutCodableProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
+extension pxr.VtTokenArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
 
-extension pxr.VtQuathArray: __Overlay.VtArrayProtocol {}
-extension pxr.VtQuatfArray: __Overlay.VtArrayProtocol {}
-extension pxr.VtQuatdArray: __Overlay.VtArrayProtocol {}
-extension pxr.VtQuaternionArray: __Overlay.VtArrayProtocol {}
+extension pxr.VtQuathArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
+extension pxr.VtQuatfArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
+extension pxr.VtQuatdArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
+extension pxr.VtQuaternionArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}
 
-extension Overlay.SdfAssetPath_VtArray: __Overlay.VtArrayProtocol {}
+extension Overlay.SdfAssetPath_VtArray: __Overlay.VtArrayProtocol {
+    public mutating func __assign(_ p: UnsafeBufferPointer<ElementType>) {
+        __Overlay.VtArray_assign(&self, p.baseAddress, p.baseAddress.map { $0 + p.count })
+    }
+}


### PR DESCRIPTION
### Description
This PR adds a borrowing `withUnsafeBufferPointer(_:)` to the `VtArray` protocols, backed by `cdata()` so the read never detaches the copy-on-write storage, and an `init(_: UnsafeBufferPointer)` that assigns a contiguous buffer in a single copy rather than element-by-element `push_back`s. The initializer is the write-side complement of `cdata()`'s zero-copy reads.

### Related Issues / PRs
* **Resolves:** #34 
* **Depends on Test PR:** https://github.com/apple/SwiftUsd-Tests/pull/15

### Checklist
- [x] Followed the contribution guidelines in `CONTRIBUTING.md`
- [x] Omitted local generation artifacts (`Package.swift` / `swift-package`) from the commit
- [x] Added corresponding verification tests in the test suite