### PR TITLE
Add a deprecated diagnostic on pxr.HioImage.OpenForReading/OpenForWriting

### DIFF
--- a/SwiftUsd.docc/AboutThisRepo/ChangeLog.md
+++ b/SwiftUsd.docc/AboutThisRepo/ChangeLog.md
@@ -15,6 +15,7 @@ Changes to SwiftUsd
 Released TBD, based on OpenUSD TBD
 - Add zero-copy `VtArray` reads via `withUnsafeBufferPointer(_:)` and single-copy construction from an `UnsafeBufferPointer`
 - Add Embree to the default Swift Package for iOS, visionOS, and simulators
+- Mark `pxr.HioImage.OpenForReading`/`OpenForWriting` as deprecated with the `Overlay.HioImage` versions as preferred
 
 ### 8.0.0
 Released 2026-07-22, based on OpenUSD v26.08

--- a/source/SwiftOverlay/SwiftSubclassCxx_handwritten.swift
+++ b/source/SwiftOverlay/SwiftSubclassCxx_handwritten.swift
@@ -59,3 +59,38 @@ extension __Overlay {
         }
     }
 }
+
+
+
+
+
+
+
+extension pxr.HioImage {
+    // Note: In 9.0.0, change `deprecated` to `unavailable`. (Can't do it sooner without breaking source compatibility)
+    
+    /// Most users should use Overlay.HioImageWrapper instead of pxr.HioImage due to potential
+    /// memory safety issues. Only use pxr.HioImage if you're writing an HioImage plugin in Swift
+    @_documentation(visibility: internal)
+    @available(*, deprecated, message: "Use Overlay.HioImageWrapper.OpenForReading(_:_:_:_:_:) instead")
+    public static func OpenForReading(_ filename: std.string,
+                                      _ subimage: CInt = 0,
+                                      _ mip: CInt = 0,
+                                      _ sourceColorSpace: pxr.HioImage.SourceColorSpace = .init(rawValue: 2),
+                                      _ suppressErrors: Bool = false) -> pxr.HioImageSharedPtr {
+        // Nit: Should be `_ sourceColorSpace: pxr.HioImage.SourceColorSpace = .Auto`,
+        // but that's a nested unscoped enum case, and in ast-answerer, SwiftSubclassCxx currently bypasses Import,
+        // so FindEnums and EnumsCodeGen don't touch it. Not worth exposing by hand or via ast-answerer
+        // just for this safety diagnostic that'll become unavailable in SwiftUsd 9.0.0. 
+        
+        return __OpenForReadingUnsafe(filename, subimage, mip, sourceColorSpace, suppressErrors)
+    }
+
+    /// Most users should use Overlay.HioImageWrapper instead of pxr.HioImage due to potential
+    /// memory safety issues. Only use pxr.HioImage if you're writing an HioImage plugin in Swift
+    @_documentation(visibility: internal)
+    @available(*, deprecated, message: "Use Overlay.HioImageWrapper.OpenForWriting(_:) instead")
+    public static func OpenForWriting(_ filename: std.string) -> pxr.HioImageSharedPtr {
+        return __OpenForWritingUnsafe(filename)
+    }
+}

--- a/source/generated/Sendable.md
+++ b/source/generated/Sendable.md
@@ -2780,7 +2780,7 @@ Use this extension method sparingly!
 - `pxr.UsdSkelImagingDataSourceBlendShapePrim`
 - `pxr.UsdSkelImagingDataSourceBlendShapePrimAtomicHandle`
 - `pxr.UsdSkelImagingDataSourceResolvedPointsBasedPrim`
-- `pxr.UsdSkelImagingDataSourceResolvedPointsBasedPrimHandle`
+- `pxr.UsdSkelImagingDataSourceResolvedPointsBasedPrimAtomicHandle`
 - `pxr.UsdSkelImagingResolvedSkeletonSchema`
 - `pxr.UsdSkelImagingResolvedSkeletonSchema.Builder`
 - `pxr.UsdSkelImagingDataSourceXformResolver`

--- a/source/generated/Sendable.swift
+++ b/source/generated/Sendable.swift
@@ -3683,7 +3683,7 @@ extension pxr.TfStackedAccess: @unchecked Sendable {}
 extension pxr.TfToken: @unchecked Sendable {}
 extension pxr.TraceAggregateTree.EventTimes: @unchecked Sendable {}
 extension pxr.UsdSchemaRegistry.TokenToTokenVectorMap: @unchecked Sendable {}
-extension pxr.TfTokenVector: @unchecked Sendable {}
+extension pxr.SdrIdentifierVec: @unchecked Sendable {}
 extension pxr.SdrOptionVec: @unchecked Sendable {}
 extension pxr.UsdGeomBasisCurves.ComputeInterpolationInfo: @unchecked Sendable {}
 extension pxr.SdrOption: @unchecked Sendable {}
@@ -3962,7 +3962,9 @@ extension pxr.HdInstancerContext: @unchecked Sendable {}
 #endif // #if canImport(SwiftUsd_PXR_ENABLE_IMAGING_SUPPORT)
 extension pxr.SdfRelocate: @unchecked Sendable {}
 extension pxr.UsdUtilsPathHashSet: @unchecked Sendable {}
-extension pxr.PcpPrimIndexInputs.PayloadSet: @unchecked Sendable {}
+#if canImport(SwiftUsd_PXR_ENABLE_IMAGING_SUPPORT)
+extension pxr.PathSet: @unchecked Sendable {}
+#endif // #if canImport(SwiftUsd_PXR_ENABLE_IMAGING_SUPPORT)
 extension pxr.SdfPath.Hash: @unchecked Sendable {}
 extension pxr.PcpMapFunction.PathMap: @unchecked Sendable {}
 extension pxr.SdfPath.FastLessThan: @unchecked Sendable {}
@@ -6413,7 +6415,7 @@ extension pxr.UsdIrImagingTokens_StaticTokenType: @unchecked Sendable {}
 @available(*, unavailable) extension pxr.UsdSkelImagingDataSourceBlendShapePrim: @unchecked Sendable {}
 @available(*, unavailable) extension pxr.UsdSkelImagingDataSourceBlendShapePrimAtomicHandle: @unchecked Sendable {}
 @available(*, unavailable) extension pxr.UsdSkelImagingDataSourceResolvedPointsBasedPrim: @unchecked Sendable {}
-@available(*, unavailable) extension pxr.UsdSkelImagingDataSourceResolvedPointsBasedPrimHandle: @unchecked Sendable {}
+@available(*, unavailable) extension pxr.UsdSkelImagingDataSourceResolvedPointsBasedPrimAtomicHandle: @unchecked Sendable {}
 @available(*, unavailable) extension pxr.UsdSkelImagingResolvedSkeletonSchema: @unchecked Sendable {}
 @available(*, unavailable) extension pxr.UsdSkelImagingResolvedSkeletonSchema.Builder: @unchecked Sendable {}
 @available(*, unavailable) extension pxr.UsdSkelImagingDataSourceXformResolver: @unchecked Sendable {}

--- a/source/generated/_OpenUSD_SwiftBindingHelpers.apinotes
+++ b/source/generated/_OpenUSD_SwiftBindingHelpers.apinotes
@@ -515,6 +515,13 @@ Namespaces:
     SwiftImportAs: reference
     SwiftRetainOp: immortal
     SwiftReleaseOp: immortal
+    # SwiftSafety: unsafe
+    Methods:
+    - Name: OpenForReading
+      SwiftName: __OpenForReadingUnsafe(_:_:_:_:_:)
+
+    - Name: OpenForWriting
+      SwiftName: __OpenForWritingUnsafe(_:)
 
   - Name: HioImageRegistry
     SwiftImportAs: reference


### PR DESCRIPTION
The diagnostic directs users to Overlay.HioImageWrapper.OpenForReading/OpenForWriting instead
ast-answerer: https://github.com/apple/SwiftUsd-ast-answerer/pull/8